### PR TITLE
Add matching series titles based on provider IDs for Jellyfin

### DIFF
--- a/.changeset/early-apes-join.md
+++ b/.changeset/early-apes-join.md
@@ -1,0 +1,5 @@
+---
+"unmonitorr": minor
+---
+
+Improve Sonarr series detection in Jellyfin by using the series' TVDB ID

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -17,11 +17,9 @@ export const radarrApi = RADARR_API_KEY
     })
   : undefined;
 
-export const sonarrApi = SONARR_API_KEY
-  ? createClient<sonarrPaths>({
-      baseUrl: SONARR_HOST,
-      headers: {
-        'X-Api-Key': SONARR_API_KEY,
-      },
-    })
-  : undefined;
+export const sonarrApi = createClient<sonarrPaths>({
+  baseUrl: SONARR_HOST,
+  headers: {
+    'X-Api-Key': SONARR_API_KEY,
+  },
+});

--- a/src/jellyfin.ts
+++ b/src/jellyfin.ts
@@ -1,6 +1,7 @@
 import type { Express, Request, Response } from 'express';
 import express from 'express';
 import type { ParamsDictionary } from 'express-serve-static-core';
+import { sonarrApi } from './fetch.ts';
 import { unmonitorMovie } from './radarr.ts';
 import { unmonitorEpisode } from './sonarr.ts';
 
@@ -23,10 +24,19 @@ export function startJellyfinUnmonitor(app: Express) {
 
       switch (Item.Type) {
         case 'Episode': {
+          if (!sonarrApi) {
+            return;
+          }
+
           const episodeTvdbIds = [Item.ProviderIds.Tvdb];
           const seriesTitle = Series.OriginalTitle;
+          const seriesTvdbId = Series.ProviderIds['Tvdb'];
 
-          await unmonitorEpisode({ episodeTvdbIds, seriesTitle });
+          await unmonitorEpisode({
+            episodeTvdbIds,
+            seriesTitle,
+            seriesTvdbId,
+          });
           break;
         }
         case 'Movie': {

--- a/src/jellyfin.ts
+++ b/src/jellyfin.ts
@@ -1,7 +1,6 @@
 import type { Express, Request, Response } from 'express';
 import express from 'express';
 import type { ParamsDictionary } from 'express-serve-static-core';
-import { sonarrApi } from './fetch.ts';
 import { unmonitorMovie } from './radarr.ts';
 import { unmonitorEpisode } from './sonarr.ts';
 
@@ -24,10 +23,6 @@ export function startJellyfinUnmonitor(app: Express) {
 
       switch (Item.Type) {
         case 'Episode': {
-          if (!sonarrApi) {
-            return;
-          }
-
           const episodeTvdbIds = [Item.ProviderIds.Tvdb];
           const seriesTitle = Series.OriginalTitle;
           const seriesTvdbId = Series.ProviderIds['Tvdb'];

--- a/src/plex.ts
+++ b/src/plex.ts
@@ -2,7 +2,6 @@ import type { Express, Request, Response } from 'express';
 import type { ParamsDictionary } from 'express-serve-static-core';
 import multer from 'multer';
 import { PLEX_ACCOUNTS, PLEX_EVENTS } from './constants.ts';
-import { sonarrApi } from './fetch.ts';
 import { unmonitorMovie } from './radarr.ts';
 import { unmonitorEpisode } from './sonarr.ts';
 import type { PlexBody, PlexPayload } from './types/plex.ts';
@@ -50,10 +49,6 @@ export function startPlexUnmonitor(app: Express) {
 
       switch (Metadata.type) {
         case 'episode': {
-          if (!sonarrApi) {
-            return;
-          }
-
           const { Guid, grandparentTitle: seriesTitle } = Metadata;
           const episodeTvdbIds = getIds(Guid, 'tvdb');
 

--- a/src/plex.ts
+++ b/src/plex.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from 'express';
 import type { ParamsDictionary } from 'express-serve-static-core';
 import multer from 'multer';
 import { PLEX_ACCOUNTS, PLEX_EVENTS } from './constants.ts';
+import { sonarrApi } from './fetch.ts';
 import { unmonitorMovie } from './radarr.ts';
 import { unmonitorEpisode } from './sonarr.ts';
 import type { PlexBody, PlexPayload } from './types/plex.ts';
@@ -49,6 +50,10 @@ export function startPlexUnmonitor(app: Express) {
 
       switch (Metadata.type) {
         case 'episode': {
+          if (!sonarrApi) {
+            return;
+          }
+
           const { Guid, grandparentTitle: seriesTitle } = Metadata;
           const episodeTvdbIds = getIds(Guid, 'tvdb');
 

--- a/src/sonarr.ts
+++ b/src/sonarr.ts
@@ -1,138 +1,201 @@
 import { sonarrApi } from './fetch.ts';
+import type { components } from './types/sonarr.ts';
 import { cleanTitle, hasExclusionTag } from './utils.ts';
 
-export async function unmonitorEpisode({
-  episodeTvdbIds,
-  seriesTitle,
-}: {
-  episodeTvdbIds: string[];
-  seriesTitle: string;
-}): Promise<void> {
-  if (!sonarrApi) {
-    return;
-  }
+type Series = components['schemas']['SeriesResource'];
+type Episode = components['schemas']['EpisodeResource'];
 
-  // tvdbId is of the episode not the series.
-  if (episodeTvdbIds.length === 0) {
-    console.warn(`No tvdbId for ${seriesTitle}`);
-    return;
-  }
-
-  // Sonarr has no api for getting an episode by episode tvdbId
-  // Go through the following steps to get the matching episode:
-  // 1. Get series list
-  // 2. Match potential series on title
-  // 3. Get episode lists
-  // 4. Match episode on tvdbId
+async function getSeriesList(): Promise<Series[]> {
   const { data: seriesList, error: seriesError } =
     await sonarrApi.GET('/api/v3/series');
-
-  if (seriesError) {
-    console.error('Failed to get series lists from sonarr:');
-    console.error(seriesError);
-    return;
+  if (seriesError || !seriesList) {
+    throw {
+      message: `Failed to get series lists from Sonarr.\n${seriesError}`,
+      level: 'error',
+    };
   }
 
-  if (!seriesList) {
-    return;
+  return seriesList;
+}
+
+function findSeries(
+  seriesList: Series[],
+  title: string,
+  seriesTvdbId?: string,
+): Series {
+  if (seriesTvdbId) {
+    const seriesById = seriesList.find(
+      (s) => String(s.tvdbId) === seriesTvdbId,
+    );
+    if (seriesById) return seriesById;
   }
 
-  const cleanedTitle = cleanTitle(seriesTitle);
   // Match potential series on title. Year metadata from Plex is for the episode
   // so cannot be used for series filtering.
-  const seriesMatches = seriesList.filter(
-    ({ title }) =>
-      typeof title === 'string' && cleanTitle(title) === cleanedTitle,
+  const cleanedTitle = cleanTitle(title);
+  const foundSeries = seriesList.find(
+    (s) => cleanTitle(s.title ?? '') === cleanedTitle,
   );
-  if (seriesMatches.length === 0) {
-    console.warn(`Could not find ${seriesTitle} in sonarr library`);
-    return;
+  if (!foundSeries) {
+    throw {
+      message: `Could not find '${title}' in Sonarr library`,
+      level: 'warn',
+    };
   }
 
-  let episode = null;
-  let series = null;
+  return foundSeries;
+}
 
-  for (const seriesMatch of seriesMatches) {
-    if (!seriesMatch.id) {
-      continue;
-    }
-    const { data: episodeList, error: episodeError } = await sonarrApi.GET(
-      '/api/v3/episode',
-      {
-        params: {
-          query: {
-            seriesId: seriesMatch.id,
-          },
-        },
-      },
-    );
-
-    if (episodeError) {
-      console.error(`Failed to get episode list for ${seriesTitle}:`);
-      console.error(episodeError);
-      continue;
-    }
-
-    if (!episodeList) {
-      continue;
-    }
-
-    episode = episodeList.find(
-      ({ tvdbId }) => tvdbId && episodeTvdbIds.includes(tvdbId.toString()),
-    );
-    if (episode) {
-      series = seriesMatch;
-      break;
-    }
-  }
-  if (
-    !series ||
-    episode?.seasonNumber == null ||
-    episode.episodeNumber == null
-  ) {
-    console.warn(
-      `Could not find episode tvdbIds: ${episodeTvdbIds.toString()} for ${seriesTitle}`,
-    );
-    return;
+async function findEpisodeInSeries(
+  series: Series,
+  episodeTvdbIds: string[],
+): Promise<{ series: Series; episode: Episode }> {
+  if (episodeTvdbIds.length === 0) {
+    throw {
+      message: `No episode TvdbId for ${series.title}`,
+      level: 'warn',
+    };
   }
 
-  const episodeString = `${seriesTitle} - S${episode.seasonNumber.toString()}E${episode.episodeNumber.toString()}`;
-
-  if (!episode.monitored) {
-    console.warn(`${episodeString} is already unmonitored`);
-    return;
+  if (series.id === undefined) {
+    throw {
+      message: `Series ID is undefined for ${series.title}`,
+      level: 'warn',
+    };
   }
 
-  if (episode.id == null) {
-    console.warn(`${episodeString} has no id`);
-    return;
+  const { data: episodeList, error: episodeError } = await sonarrApi.GET(
+    '/api/v3/episode',
+    {
+      params: { query: { seriesId: series.id } },
+    },
+  );
+
+  if (episodeError || !episodeList) {
+    throw {
+      message: `Failed to get episode list for ${series.title}\n${episodeError}`,
+      level: 'error',
+    };
   }
 
+  const foundEpisode = episodeList.find(
+    (ep) => ep.tvdbId && episodeTvdbIds.includes(String(ep.tvdbId)),
+  );
+
+  if (!foundEpisode) {
+    throw {
+      message: `Could not find episode (tvdbId: ${episodeTvdbIds.join(', ')}) for ${series.title}`,
+      level: 'warn',
+    };
+  }
+
+  return { series, episode: foundEpisode };
+}
+
+async function checkExclusionTag(
+  series: Series,
+  episodeString: string,
+): Promise<void> {
   const { data: tags, error: tagsError } = await sonarrApi.GET('/api/v3/tag');
-
-  if (tagsError) {
-    console.error(`Failed to get tags information from sonarr`);
-    console.error(tagsError);
-    return;
+  if (tagsError || !tags) {
+    throw {
+      message: `Failed to get tags from Sonarr\n${tagsError}`,
+      level: 'error',
+    };
   }
 
   if (hasExclusionTag(tags, series.tags)) {
-    console.warn(`${episodeString} has exclusion tag`);
-    return;
+    throw {
+      message: `${episodeString} has an exclusion tag, skipping`,
+      level: 'warn',
+    };
+  }
+}
+
+async function unmonitorEpisodeStatus(
+  episode: Episode,
+  episodeString: string,
+): Promise<void> {
+  if (episode.id == null) {
+    throw {
+      message: `${episodeString} has no id`,
+      level: 'warn',
+    };
   }
 
-  const { error } = await sonarrApi.PUT('/api/v3/episode/monitor', {
-    body: {
-      episodeIds: [episode.id],
-      monitored: false,
-    },
-  });
+  if (!episode.monitored) {
+    throw {
+      message: `${episodeString} is already unmonitored.`,
+      level: 'warn',
+    };
+  }
 
-  if (error) {
-    console.error(`Failed to unmonitor ${episodeString}:`);
-    console.error(error);
-    return;
+  const { error: unmonitorError } = await sonarrApi.PUT(
+    '/api/v3/episode/monitor',
+    {
+      body: {
+        episodeIds: [episode.id],
+        monitored: false,
+      },
+    },
+  );
+
+  if (unmonitorError) {
+    throw {
+      message: `Failed to unmonitor ${episodeString}\n${unmonitorError}`,
+      level: 'error',
+    };
   }
 
   console.log(`${episodeString} unmonitored!`);
+}
+
+// Sonarr has no api for getting an episode by episode tvdbId
+// Go through the following steps to get the matching episode:
+// 1. Get series list
+// 2. Match potential series on id
+// 3. If series id match failed, match potential series on title
+// 4. Get episode lists
+// 5. Match episode on tvdbId
+export async function unmonitorEpisode({
+  episodeTvdbIds,
+  seriesTitle,
+  seriesTvdbId,
+}: {
+  episodeTvdbIds: string[];
+  seriesTitle: string;
+  seriesTvdbId?: string | undefined;
+}): Promise<void> {
+  try {
+    const seriesList = await getSeriesList();
+
+    const foundSeries = findSeries(seriesList, seriesTitle, seriesTvdbId);
+
+    const { series, episode } = await findEpisodeInSeries(
+      foundSeries,
+      episodeTvdbIds,
+    );
+
+    const episodeString = `${series.title} - S${episode.seasonNumber}E${episode.episodeNumber}`;
+
+    await checkExclusionTag(series, episodeString);
+
+    await unmonitorEpisodeStatus(episode, episodeString);
+  } catch (e) {
+    const error = e as { message: string; level: string };
+
+    switch (error.level) {
+      case 'warn':
+        console.warn(error.message);
+        break;
+      case 'error':
+        console.error(error.message);
+        break;
+      default:
+        console.error(
+          'An unexpected error occurred while unmonitoring episode.',
+        );
+        break;
+    }
+  }
 }

--- a/src/sonarr.ts
+++ b/src/sonarr.ts
@@ -112,7 +112,7 @@ async function checkExclusionTag(
   }
 }
 
-async function unmonitorEpisodeStatus(
+async function setEpisodeUnmonitored(
   episode: Episode,
   episodeString: string,
 ): Promise<void> {
@@ -166,6 +166,10 @@ export async function unmonitorEpisode({
   seriesTitle: string;
   seriesTvdbId?: string | undefined;
 }): Promise<void> {
+  if (!sonarrApi) {
+    return;
+  }
+
   try {
     const seriesList = await getSeriesList();
 
@@ -180,7 +184,7 @@ export async function unmonitorEpisode({
 
     await checkExclusionTag(series, episodeString);
 
-    await unmonitorEpisodeStatus(episode, episodeString);
+    await setEpisodeUnmonitored(episode, episodeString);
   } catch (e) {
     const error = e as { message: string; level: string };
 


### PR DESCRIPTION
Match series titles based on provider ID in Jellyfin. If no Jellyfin ID matches Sonarr IDs, falls back to `Series.OriginalTitle` matching.