### PR TITLE
Potential fix for code scanning alert no. 9: Code injection

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -55,6 +55,8 @@ jobs:
       # Step 6: Commit and push ONLY the src directory changes back to the fork.
       - name: Commit changes
         working-directory: ./.pr-code-to-lint
+        env:
+          TARGET_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -65,5 +67,5 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "style: apply automatic linting fixes"
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            git push origin HEAD:$TARGET_REF
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/Shraymonks/unmonitorr/security/code-scanning/9](https://github.com/Shraymonks/unmonitorr/security/code-scanning/9)

**General fix:**  
Remove direct expression interpolation in the shell command. Instead, assign the untrusted value to an environment variable, and then reference it in the shell script using proper shell variable syntax.

**Detailed fix:**  
- Add an `env` section to the step for committing changes, assigning a new environment variable such as `TARGET_REF` to be `${{ github.event.pull_request.head.ref }}`.
- In the shell script, use `$TARGET_REF` instead of expression interpolation. This change ensures the argument is treated as a single parameter by the shell, protecting against command injection.
- No changes to logic or behavior (the ref name is still passed to git, only in a safe manner).
- Only lines in the final commit step (`- name: Commit changes`) need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
